### PR TITLE
feat: use getter func when it's available

### DIFF
--- a/testdata/testmod/domain/address.go
+++ b/testdata/testmod/domain/address.go
@@ -5,8 +5,16 @@ type Address struct {
 	Street       string
 	StringValues []string
 	Date         Date1
+	Line1        *string
 }
 
 type Date1 struct {
 	Year int
+}
+
+func (a *Address) GetLine1() string {
+	if a != nil && a.Line1 != nil {
+		return *a.Line1
+	}
+	return ""
 }

--- a/testdata/testmod/mapper/todo_mapper_test.go
+++ b/testdata/testmod/mapper/todo_mapper_test.go
@@ -39,6 +39,8 @@ func TestTodoMapper(t *testing.T) {
 		t.Fatal(err)
 	}
 	todoMapper, _ := obj.(TodoMapper)
+	line1 := "300 Street Street"
+	line1Expect := line1
 
 	source := &model.TodoModel{
 		Id:     1,
@@ -49,6 +51,7 @@ func TestTodoMapper(t *testing.T) {
 			Date: &model.Date1{
 				Year: "2021",
 			},
+			Line1: &line1,
 		},
 		Title: "Write unit tests",
 		Type:  1,
@@ -80,6 +83,7 @@ func TestTodoMapper(t *testing.T) {
 				Date: domain.Date1{
 					Year: 2021,
 				},
+				Line1: &line1Expect,
 			},
 		},
 		Title: "Write unit tests",

--- a/testdata/testmod/model/address.go
+++ b/testdata/testmod/model/address.go
@@ -5,6 +5,7 @@ type AddressModel struct {
 	Street    []int
 	IntValues []int
 	Date      *Date1
+	Line1     *string
 }
 
 type Date1 struct {


### PR DESCRIPTION
1. support GetXXX pattern as getter
2. support getter on non-private attributes
3. prefer to use getter func over the direct attribute when getter is available
4. support getter/setter/attribute has different type (pointer vs non-pointer)
5. fix typo on missing %s string format specifier