### PR TITLE
fix: infer type pointer

### DIFF
--- a/internal/gen.go
+++ b/internal/gen.go
@@ -523,29 +523,28 @@ func NewObjectPropertyMappingValue(base string, named *types.Named, name string,
 	if len(parts) > 1 {
 		baseName = base + "." + strings.Join(parts[:len(parts)-1], ".")
 	}
-
-	ret := &objectPropertyMappingValue{
-		base: base,
-	}
-
 	st, ok := GetStructType(named)
 	if ok {
 		f, ok := GetField(st, name, ignoreCase)
 		if ok && f.Exported() {
-			ret.base = baseName
-			ret.exportedFieldName = f.Name()
-			ret.exportedFieldType = f.Type()
+			return &objectPropertyMappingValue{
+				base:              baseName,
+				exportedFieldName: f.Name(),
+				exportedFieldType: f.Type(),
+			}, true
 		}
+	}
+
+	ret := &objectPropertyMappingValue{
+		base: base,
 	}
 
 	setter, ok := GetMethod(named, "Set"+name, ignoreCase)
 	if ok && setter.Exported() && GetParamsCount(setter) == 1 {
 		ret.setter = setter
 	}
-
-	if getter, ok := GetMethod(named, name, ignoreCase); ok && getter.Exported() && GetParamsCount(getter) == 0 {
-		ret.getter = getter
-	} else if getter, ok := GetMethod(named, "Get"+name, ignoreCase); ok && getter.Exported() && GetParamsCount(getter) == 0 {
+	getter, ok := GetMethod(named, name, ignoreCase)
+	if ok && getter.Exported() && GetParamsCount(getter) == 0 {
 		ret.getter = getter
 	}
 	if ret.CanGet() || ret.CanSet() {

--- a/testdata/testmod/domain/user.go
+++ b/testdata/testmod/domain/user.go
@@ -6,5 +6,6 @@ type User struct {
 	ID        string
 	Name      string
 	UpdatedAt time.Time
+	DeletedAt *time.Time
 	Address   *Address
 }

--- a/testdata/testmod/mapper/user_mapper_test.go
+++ b/testdata/testmod/mapper/user_mapper_test.go
@@ -55,6 +55,54 @@ func TestUserNammer(t *testing.T) {
 	}
 }
 
+func TestUserNonNilDeletedAt(t *testing.T) {
+	mappers := NewMappers()
+	mapper.AddTimeToStringConverter(mappers)
+	mapper.AddStreetConverter(mappers)
+	mapper.AddIntStringConverter(mappers)
+	ctx := context.TODO()
+
+	userMapper, err := sesame.Get[UserMapper](mappers, "UserMapper")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source := &model.UserModel{
+		ID:        "id1",
+		Name:      "name1",
+		UpdatedAt: "2024-07-18T10:15:36Z",
+		DeletedAt: toPtr("2024-07-18T10:15:36Z"),
+		Address: &model.AddressModel{
+			Pref:      "Tokyo",
+			Street:    []int{1, 2, 3},
+			IntValues: []int{10, 11, 12},
+		},
+	}
+	var entity domain.User
+	err = userMapper.UserModelToUser(ctx, source, &entity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := &domain.User{
+		ID:        "id1",
+		Name:      "name1",
+		UpdatedAt: mustTime("2024-07-18T10:15:36Z"),
+		DeletedAt: toPtr(mustTime("2024-07-18T10:15:36Z")),
+		Address: &domain.Address{
+			Pref:         "Tokyo",
+			Street:       "1-2-3",
+			StringValues: []string{"10", "11", "12"},
+		},
+	}
+	if diff := cmp.Diff(expected, &entity); len(diff) != 0 {
+		t.Errorf("Compare value is mismatch(-:expected, +:actual) :%s\n", diff)
+	}
+}
+
+func toPtr[T any](s T) *T {
+	return &s
+}
+
 func TestIntermediateNil(t *testing.T) {
 	mappers := NewMappers()
 

--- a/testdata/testmod/model/user.go
+++ b/testdata/testmod/model/user.go
@@ -4,5 +4,6 @@ type UserModel struct {
 	ID        string
 	Name      string
 	UpdatedAt string
+	DeletedAt *string
 	Address   *AddressModel
 }


### PR DESCRIPTION
There was a regression in a previous PR: https://github.com/RoryQ/sesame/commit/4059054ececd960683042c9af368b382a800a40b

There was not a test against this change previously and so the effect was not known at the time.

This is simply reversing the change and fixing the bug introduced then.